### PR TITLE
Improve immersion with slower typewriter

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,21 +46,21 @@
 
         <div class="bloque bloque-2">
             <div class="setup-control-group" style="margin-top: 20px; margin-bottom: 20px;">
-                <label for="event-date-input">🗓️ ¿<strong>Cuándo juegas</strong>?</label>
+                <label for="event-date-input" class="typewriter" data-type-speed="100">🗓️ ¿<strong>Cuándo juegas</strong>?</label>
                 <input type="date" id="event-date-input" class="player-name-box" />
             </div>
         </div>
 
         <div class="bloque bloque-3">
             <div class="setup-control-group" style="margin-bottom: 15px;">
-                <label for="host-name-input">Tu Nombre (<strong>Organizador</strong>):</label>
+                <label for="host-name-input" class="typewriter" data-type-speed="100">Tu Nombre (<strong>Organizador</strong>):</label>
                 <input class="player-name-box" id="host-name-input" placeholder="Nombre del Organizador" type="text"/>
             </div>
         </div>
 
         <div class="bloque bloque-4">
             <div class="setup-control-group" style="margin-bottom: 5px; display: flex; align-items: center;">
-                <span class="font-normal" style="font-weight:normal; text-transform: none; letter-spacing: normal; margin-right:8px;">¿Hay <strong>homenajead@</strong>?</span>
+                <span class="font-normal typewriter" style="font-weight:normal; text-transform: none; letter-spacing: normal; margin-right:8px;" data-type-speed="100">¿Hay <strong>homenajead@</strong>?</span>
                 <div class="honoree-choice-container">
                     <button type="button" id="honoree-yes" class="honoree-choice-btn">Sí</button>
                     <button type="button" id="honoree-no" class="honoree-choice-btn">No</button>
@@ -73,7 +73,7 @@
 
         <div class="bloque bloque-5">
             <div class="setup-control-group">
-                <label for="player-count">Número de Jugadores: </label>
+                <label for="player-count" class="typewriter" data-type-speed="100">Número de Jugadores: </label>
                 <div class="player-count-wrapper">
                     <button type="button" id="decrement-player-count" class="player-count-btn" aria-label="Disminuir número de jugadores">-</button>
                     <input id="player-count" max="20" min="8" type="number" value="8"/>
@@ -84,7 +84,7 @@
 
         <div class="bloque bloque-6">
             <div class="setup-control-group">
-                <label id="player-names-label">Nombres de los <strong>Jugadores</strong>:</label>
+                <label id="player-names-label" class="typewriter" data-type-speed="100">Nombres de los <strong>Jugadores</strong>:</label>
                 <div id="player-names-grid-container"></div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -1174,15 +1174,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
 const textoIntro = "🕵️‍♂️ Archivo Confidencial: Testamento Collins";
 let i = 0;
-const speed = 75;
+const speed = 100;
 
-function typeWriter() {
-  const el = document.getElementById("typewriter-title");
-  if (el && i < textoIntro.length) {
-    el.textContent += textoIntro.charAt(i);
-    i++;
-    setTimeout(typeWriter, speed);
-  }
+function runTypewriterOnElement(el, txt, delay = 90) {
+  if (!el) return;
+  const text = txt || el.textContent;
+  el.textContent = "";
+  let idx = 0;
+  (function type() {
+    if (idx < text.length) {
+      el.textContent += text.charAt(idx);
+      idx++;
+      setTimeout(type, delay);
+    }
+  })();
+}
+
+
+function applyTypewriterEffects(container) {
+  if (!container) return;
+  const elements = container.querySelectorAll('.typewriter');
+  elements.forEach(el => {
+    runTypewriterOnElement(el, el.textContent, parseInt(el.dataset.typeSpeed) || 90);
+  });
 }
 
 function setupProgressiveFlow() {
@@ -1198,6 +1212,7 @@ function setupProgressiveFlow() {
       b.classList.remove('hidden-section');
       b.classList.add('visible-section');
       triggerGoldenGlow(b);
+      applyTypewriterEffects(b);
     }
   };
 
@@ -1217,7 +1232,7 @@ function setupProgressiveFlow() {
     });
   }
   if (hostInput) {
-    hostInput.addEventListener('input', () => {
+    hostInput.addEventListener('blur', () => {
       if (hostInput.value.trim().length > 0) showBloque(4);
     });
   }
@@ -1258,9 +1273,7 @@ function setupProgressiveFlow() {
 window.addEventListener("load", () => {
   const titleElement = document.getElementById("typewriter-title");
   if (titleElement) {
-    titleElement.textContent = '';
-    i = 0;
-    typeWriter();
+    runTypewriterOnElement(titleElement, textoIntro, speed);
   }
 });
 


### PR DESCRIPTION
## Summary
- slow down the typewriter effect for labels
- start the next question after the host field loses focus

## Testing
- `npx prettier -c '**/*.{js,css,html}'` *(fails: Code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68464e41e834832589e6f66926c9b579