### PR TITLE
Implement custom share menu with iPhone support

### DIFF
--- a/script.js
+++ b/script.js
@@ -643,26 +643,19 @@ function initializeApp(initialChars, initialPacks) {
                 if(d){
                     const txt = `¡Hola ${pA}!\n\nAquí tienes los detalles de tu sospechoso para el Cluedo en vivo “El Testamento de Mr. Collins”:\n\n🕵️ SOSPECHOSO: ${d.name}\n📜 DESCRIPCIÓN: ${d.description}\n\n🔗 Accede a tu ficha completa aquí: ${d.fichaLink||'N/A'}\n\n¡Recuerda que toda la información de la ficha es confidencial! 🤫`;
 
-                    if (navigator.share && navigator.canShare && navigator.canShare({ text: txt })) {
+                    const isiPhone = /iPhone/i.test(navigator.userAgent);
+                    if (isiPhone && navigator.share) {
                         try {
                             await navigator.share({
                                 title: `Sospechoso: ${d.name}`,
-                                text: txt,
+                                text: txt
                             });
                             showToastNotification('¡Detalles compartidos!', 'success');
                         } catch (error) {
                             console.error('Error al compartir:', error);
-                            if (error.name !== 'AbortError') {
-                                showToastNotification('Error al compartir. Texto copiado al portapapeles.', 'error');
-                                navigator.clipboard.writeText(txt).catch(err => console.error("Error al copiar al portapapeles:", err));
-                            } else {
-                                showToastNotification('Compartir cancelado.', 'info');
-                            }
                         }
                     } else {
-                        navigator.clipboard.writeText(txt)
-                            .then(()=>showToastNotification("Texto copiado al portapapeles.",'success'))
-                            .catch(()=>showToastNotification("Error al copiar texto.",'error'));
+                        openShareMenu(cB, txt, d.name);
                     }
                 }
             });}
@@ -740,6 +733,7 @@ function initializeApp(initialChars, initialPacks) {
 
         // --- INICIO: Lógica de Popovers ---
         let activePopoverElements = null;
+        let activeShareMenu = null;
 
         function adjustPopoverPosition(iconTriggerElement, popoverWrapper, popover, frame) {
             const iconContainer = iconTriggerElement.closest('.icono-info');
@@ -884,6 +878,47 @@ function initializeApp(initialChars, initialPacks) {
                 });
             }
         });
+
+        function closeActiveShareMenu() {
+            if (activeShareMenu) {
+                activeShareMenu.remove();
+                document.removeEventListener('click', handleShareMenuOutside);
+                activeShareMenu = null;
+            }
+        }
+
+        function handleShareMenuOutside(e) {
+            if (activeShareMenu && !activeShareMenu.contains(e.target) && e.target !== activeShareMenu.trigger) {
+                closeActiveShareMenu();
+            }
+        }
+
+        function openShareMenu(trigger, txt, name) {
+            closeActiveShareMenu();
+
+            const menu = document.createElement('div');
+            menu.className = 'share-menu';
+            menu.innerHTML = `
+                <a href="https://wa.me/?text=${encodeURIComponent(txt)}" target="_blank">🟢 WhatsApp</a>
+                <button type="button" class="share-copy-option">📋 Copiar al portapapeles</button>
+                <a href="mailto:?subject=${encodeURIComponent('Tu personaje en el Cluedo: ' + name)}&body=${encodeURIComponent(txt)}">✉️ Enviar por email</a>
+            `;
+            document.body.appendChild(menu);
+            const rect = trigger.getBoundingClientRect();
+            menu.style.left = rect.left + window.scrollX + 'px';
+            menu.style.top = rect.bottom + window.scrollY + 'px';
+
+            menu.querySelector('.share-copy-option').addEventListener('click', () => {
+                navigator.clipboard.writeText(txt)
+                    .then(() => showToastNotification('Texto copiado al portapapeles', 'success'))
+                    .catch(() => showToastNotification('Error al copiar texto', 'error'));
+                closeActiveShareMenu();
+            });
+
+            activeShareMenu = menu;
+            activeShareMenu.trigger = trigger;
+            setTimeout(() => document.addEventListener('click', handleShareMenuOutside));
+        }
         // --- FIN: Lógica de Popovers ---
 
 // 👉👉 FIN BLOQUE 3: RENDERIZADO DE UI Y COMPONENTES VISUALES 👈👈

--- a/style.css
+++ b/style.css
@@ -1046,6 +1046,42 @@ button .fas, button .fab { margin-right: 8px; }
     height: 22px;
 }
 
+.share-menu {
+    position: absolute;
+    background: var(--color-content-bg);
+    border: 1px solid var(--color-gold-medium);
+    border-radius: 6px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+    padding: 4px 0;
+    z-index: 2000;
+    min-width: 180px;
+}
+.share-menu a,
+.share-menu button {
+    display: block;
+    width: 100%;
+    padding: 8px 15px;
+    background: none;
+    border: none;
+    text-align: left;
+    text-decoration: none;
+    color: var(--color-text-dark);
+    font-family: var(--font-body), serif;
+    cursor: pointer;
+}
+.share-menu a:hover,
+.share-menu button:hover {
+    background: rgba(0,0,0,0.05);
+}
+:root.dark-mode .share-menu a,
+:root.dark-mode .share-menu button {
+    color: var(--color-gold-light);
+}
+:root.dark-mode .share-menu a:hover,
+:root.dark-mode .share-menu button:hover {
+    background: rgba(255,255,255,0.1);
+}
+
 /* ============================================= */
 /* Estilos Popovers de Información               */
 /* ============================================= */


### PR DESCRIPTION
## Summary
- support native share on iPhone when available
- add custom share dropdown with WhatsApp, copy and email options
- style dropdown menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68473035f2bc8325a2c440b8500e2928