### PR TITLE
Fix setup names clearing

### DIFF
--- a/script.js
+++ b/script.js
@@ -287,7 +287,12 @@ function initializeApp(initialChars, initialPacks) {
             }
 
             domElements['player-count'].value = domElements['player-count'].value || "8";
-            generatePlayerNameInputs(parseInt(domElements['player-count'].value));
+
+            const existingNames = Array.from(domElements['player-names-grid-container'].querySelectorAll('input.player-name-box:not([readonly])'))
+                                       .map(input => input.value.trim())
+                                       .filter(name => name);
+
+            generatePlayerNameInputs(parseInt(domElements['player-count'].value), existingNames);
         }
 
         if(domElements['decrement-player-count'] && domElements['increment-player-count'] && domElements['player-count']) {


### PR DESCRIPTION
## Summary
- preserve existing player names when resetting the setup

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6847513fa4988325bc5100bd52081f5d